### PR TITLE
Interaction can now be interrupted

### DIFF
--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -504,7 +504,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   type: Door
   animator: {fileID: 321173357}
-  targetLocation: {fileID: 1762786305}
 --- !u!208 &321173359
 NavMeshObstacle:
   m_ObjectHideFlags: 0
@@ -861,14 +860,14 @@ NavMeshAgent:
   m_Enabled: 1
   m_AgentTypeID: 0
   m_Radius: 0.5
-  m_Speed: 3
-  m_Acceleration: 8
+  m_Speed: 4
+  m_Acceleration: 7
   avoidancePriority: 50
   m_AngularSpeed: 120
   m_StoppingDistance: 0
   m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
+  m_AutoBraking: 0
+  m_AutoRepath: 0
   m_Height: 2
   m_BaseOffset: 1
   m_WalkableMask: 4294967295
@@ -1503,7 +1502,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   type: Door
   animator: {fileID: 1247788083}
-  targetLocation: {fileID: 1145363146}
 --- !u!65 &1247788085
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -2638,7 +2636,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   type: Door
   animator: {fileID: 2139674933}
-  targetLocation: {fileID: 77078432}
 --- !u!65 &2139674935
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Door.cs
+++ b/Assets/Scripts/Door.cs
@@ -6,8 +6,6 @@ public class Door : Interactable
     public Animator animator;
     //private variables
     private bool isOpen;
-    public GameObject targetLocation;
-
     // private functions
 
     private void OpenDoor()
@@ -22,7 +20,7 @@ public class Door : Interactable
     
 
     //public functions
-    public void Interact()
+    public void trigger()
     {
         isOpen = !isOpen;
         
@@ -34,8 +32,6 @@ public class Door : Interactable
         {
             animator.SetBool("isOpen", isOpen);
         }
-        targetLocation = findNearestInteractionZone();
-        GameManager.instance.SendMessage("navToTarget", targetLocation.transform);
 
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -14,6 +14,7 @@ public class GameManager : MonoBehaviour
     public Transform uiCanvas;
     // Declare a flag to track the pause state
     bool isPaused = false;
+    public IEnumerator task;
 
     // Start is called before the first frame update
     void Start()
@@ -40,6 +41,12 @@ public class GameManager : MonoBehaviour
     {
         if (Input.GetMouseButtonDown(0))
         {
+            if (!(GameManager.instance.task == null))
+            {
+                StopCoroutine(GameManager.instance.task);
+                playerNavMeshAgent.ResetPath();
+                GameManager.instance.task = null;
+            }
             Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
             RaycastHit hit;
             if (Physics.Raycast(ray, out hit))
@@ -47,11 +54,9 @@ public class GameManager : MonoBehaviour
                 Vector3 targetLocation = hit.point;
                 GameObject interactable = hit.transform.gameObject;
 
-                
-                
                 if (interactable.tag == "Interactable")
                 {
-                    interactable.SendMessage("Interact");
+                    interactable.SendMessage("Interact", interactable);
                 }
                 // Set the target position for the nav mesh agent
                 if (interactable.tag== "Ground")

--- a/Assets/Scripts/Interactable.cs
+++ b/Assets/Scripts/Interactable.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using UnityEngine.AI;
+using System.Collections;
 using System.Collections.Generic;
 
 public class Interactable : MonoBehaviour {
@@ -23,6 +25,45 @@ public class Interactable : MonoBehaviour {
         }
 
         return children;
+    }
+
+    public void Interact(GameObject interactable)
+    {
+        if (!(GameManager.instance.task == null))
+        {
+            StopCoroutine(GameManager.instance.task);
+            GameManager.instance.task = null;
+        }
+        if (GameManager.instance.task == null)
+        {
+            GameManager.instance.task = Trigger(interactable);
+            GameObject targetLocation = findNearestInteractionZone();
+            GameManager.instance.SendMessage("navToTarget", targetLocation.transform);
+            StartCoroutine(GameManager.instance.task);
+        }
+        
+    }
+
+    IEnumerator Trigger(GameObject interactable)
+    {
+        while(!(GameManager.instance.task == null))
+        {
+            NavMeshAgent mNavMeshAgent = GameManager.instance.playerNavMeshAgent;
+            if (!mNavMeshAgent.pathPending)
+            {
+                if (mNavMeshAgent.remainingDistance <= mNavMeshAgent.stoppingDistance)
+                {
+                    if (!mNavMeshAgent.hasPath || mNavMeshAgent.velocity.sqrMagnitude == 0f)
+                    {
+                        interactable.SendMessage("trigger");
+                        GameManager.instance.task = null;
+                        yield break;
+                    }
+                }
+            }
+            yield return null;
+        }
+
     }
 
 }

--- a/Assets/Scripts/Observable.cs
+++ b/Assets/Scripts/Observable.cs
@@ -3,11 +3,8 @@ using System.Collections.Generic;
 public class Observable : Interactable
 {
     //public functions
-    public void Interact()
+    public void trigger()
     {
         Debug.Log("Eventually this message should be thrown to the UI");
-        GameObject targetLocation = findNearestInteractionZone();
-        GameManager.instance.SendMessage("navToTarget", targetLocation.transform);
-
     }
 }


### PR DESCRIPTION
Previously when queuing an interaction while another action was taking place, the player would navigate to the new target destination but still trigger the interaction with any objects that had been interacted with.

Now when ever the attempts to queue up a new interaction or move, it will stop all coroutines that had been initiated by the interaction class by removing the game managers current task.